### PR TITLE
Re-create 86 Feat: connect manual feedback to api

### DIFF
--- a/apps/web/app/api/feedback/manual/route.ts
+++ b/apps/web/app/api/feedback/manual/route.ts
@@ -4,6 +4,18 @@ export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
 
+    // TODO:
+    // - Add bearer token
+    // - Catch all possible errors
+
+    // SIMULATED ERROR
+    if (body.feedback.some((f: string) => f.toLowerCase().includes("fail"))) {
+      return NextResponse.json(
+        { message: `Validation failed: feedback cannot include 'fail'` },
+        { status: 400 },
+      );
+    }
+
     await fetch("https://dummyjson.com/products/add", {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/apps/web/app/api/feedback/manual/route.ts
+++ b/apps/web/app/api/feedback/manual/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+
+    await fetch("https://dummyjson.com/products/add", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        feedback: body.feedback,
+      }),
+    });
+
+    return NextResponse.json(
+      {
+        message: "Your feedback are analyzed successfully",
+      },
+      {
+        status: 201,
+      },
+    );
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : "Internal Server Error";
+
+    return NextResponse.json({ message }, { status: 500 });
+  }
+}

--- a/apps/web/components/feedback-form/manual-feedback-submit-button.tsx
+++ b/apps/web/components/feedback-form/manual-feedback-submit-button.tsx
@@ -4,6 +4,7 @@ import { Button } from "@repo/ui/components/button";
 import { Sparkles } from "lucide-react";
 import { PreviewFeedback } from "@/components/feedback-form/manual-feedback-tab";
 import { useState } from "react";
+import { toast } from "sonner";
 
 type Props = {
   feedback: PreviewFeedback[];
@@ -33,6 +34,7 @@ const ManualFeedbackSubmitButton = ({ feedback, onClearFeedback }: Props) => {
         return;
       }
 
+      toast.success(data.message);
       onClearFeedback();
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Unknown error");

--- a/apps/web/components/feedback-form/manual-feedback-submit-button.tsx
+++ b/apps/web/components/feedback-form/manual-feedback-submit-button.tsx
@@ -19,14 +19,23 @@ const ManualFeedbackSubmitButton = ({ feedback, onClearFeedback }: Props) => {
     setError(null);
     try {
       const feedbackOnlyString = feedback.map((item) => item.feedback);
-      await fetch("/api/feedback/manual", {
+
+      const res = await fetch("/api/feedback/manual", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ feedback: feedbackOnlyString }),
       });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setError(data.message || "Unknown error");
+        return;
+      }
+
       onClearFeedback();
-    } catch {
-      setError("Failed to upload feedback.");
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
       setLoading(false);
     }

--- a/apps/web/components/feedback-form/manual-feedback-submit-button.tsx
+++ b/apps/web/components/feedback-form/manual-feedback-submit-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@repo/ui/components/button";
-import { Send } from "lucide-react";
+import { Sparkles } from "lucide-react";
 import { PreviewFeedback } from "@/components/feedback-form/manual-feedback-tab";
 import { useState } from "react";
 
@@ -46,8 +46,8 @@ const ManualFeedbackSubmitButton = ({ feedback, onClearFeedback }: Props) => {
       <p className="flex-1 text-red-600 mb-2">{error}</p>
 
       <Button onClick={handleSubmit} disabled={loading}>
-        <Send />
-        {loading ? "Analyzing..." : "Analyze feedback"}
+        <Sparkles />
+        {loading ? "Analyzing..." : <span>Analyze feedback</span>}
       </Button>
     </div>
   );

--- a/apps/web/components/feedback-form/manual-feedback-submit-button.tsx
+++ b/apps/web/components/feedback-form/manual-feedback-submit-button.tsx
@@ -3,7 +3,6 @@
 import { Button } from "@repo/ui/components/button";
 import { Send } from "lucide-react";
 import { PreviewFeedback } from "@/components/feedback-form/manual-feedback-tab";
-import { uploadManualFeedbacks } from "@/lib/actions";
 import { useState } from "react";
 
 type Props = {
@@ -20,7 +19,11 @@ const ManualFeedbackSubmitButton = ({ feedback, onClearFeedback }: Props) => {
     setError(null);
     try {
       const feedbackOnlyString = feedback.map((item) => item.feedback);
-      await uploadManualFeedbacks(feedbackOnlyString);
+      await fetch("/api/feedback/manual", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ feedback: feedbackOnlyString }),
+      });
       onClearFeedback();
     } catch {
       setError("Failed to upload feedback.");

--- a/apps/web/components/providers.tsx
+++ b/apps/web/components/providers.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import { ThemeProvider as NextThemesProvider } from "next-themes";
+import { Toaster } from "@repo/ui/components/sonner";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
@@ -13,6 +14,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
       enableColorScheme
     >
       {children}
+      <Toaster />
     </NextThemesProvider>
   );
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -31,6 +31,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hook-form": "7.62.0",
+    "sonner": "2.0.7",
     "tailwind-merge": "^3.0.1",
     "tw-animate-css": "^1.2.4",
     "zod": "3.25.76"

--- a/packages/ui/src/components/sonner.tsx
+++ b/packages/ui/src/components/sonner.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { Toaster as Sonner, ToasterProps } from "sonner";
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme();
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  );
+};
+
+export { Toaster };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
       react-hook-form:
         specifier: 7.62.0
         version: 7.62.0(react@19.1.0)
+      sonner:
+        specifier: 2.0.7
+        version: 2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       tailwind-merge:
         specifier: ^3.0.1
         version: 3.3.1
@@ -2614,6 +2617,12 @@ packages:
   socks@2.8.6:
     resolution: {integrity: sha512-pe4Y2yzru68lXCb38aAqRf5gvN8YdjP1lok5o0J7BOHljkyCGKVz7H3vpVIXKD27rj2giOJ7DwVyk/GWrPHDWA==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -5567,6 +5576,11 @@ snapshots:
     dependencies:
       ip-address: 9.0.5
       smart-buffer: 4.2.0
+
+  sonner@2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
### Github issue

- Issue URL: #86 

### Note

- Creating new pr bc of it includes old and unstable code. Merge would be a waste anyway

### Description

- Add route for analyzing feedback
- Test requests with fake for now
- If error occurs show correctly under the form
- Feedbacks are kept on error
- Renamed `✈️ Analyze Feedback` to `✨ Analyze Feedback` for more **AI highlight** 
- Show toast on success. They kept on page changes

### New packages
- Installed `shadcn` sooner

### Checklist

- [x] Code compiles correctly
- [x] Extended the README / documentation, if necessary
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Test (`pnpm run test`) has passed locally
- [x] Lint (`pnpm run lint`) has passed locally and any fixes were made for failures

### Demo (e.g. screenshots, Gifs, Videos, link to demo)
https://github.com/user-attachments/assets/006921e2-4cc4-404e-9480-c08e51ddd45e




