### PR TITLE
Feature 147: renaming the workspace

### DIFF
--- a/apps/web/features/workspaces/new-workspace/new-workspace-modal.tsx
+++ b/apps/web/features/workspaces/new-workspace/new-workspace-modal.tsx
@@ -1,12 +1,10 @@
-"use client";
-
 import { Dialog, DialogTrigger } from "@repo/ui/components/dialog";
 import { toast } from "sonner";
 import { clientAuthGuard } from "@/utils/client-auth-guard";
 import { createNewWorkspace } from "@/lib/actions/workspaces";
 import { ReactNode } from "react";
 import WorkspaceModalContent, {
-  WorkspaceFormValues,
+  type WorkspaceFormValues,
 } from "@/features/workspaces/workspace-modal-content";
 
 type Props = {

--- a/apps/web/features/workspaces/rename-workspace/rename-workspace-modal.tsx
+++ b/apps/web/features/workspaces/rename-workspace/rename-workspace-modal.tsx
@@ -1,47 +1,12 @@
 "use client";
 
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@repo/ui/components/dialog";
-import { Button } from "@repo/ui/components/button";
-import { Input } from "@repo/ui/components/input";
-import { z } from "zod";
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@repo/ui/components/form";
+import { Dialog } from "@repo/ui/components/dialog";
 import { toast } from "sonner";
 import { clientAuthGuard } from "@/utils/client-auth-guard";
-import { renameNewWorkspace } from "@/lib/actions/workspaces"; // <- replace with renameWorkspace when available
-import {
-  NEW_WORKSPACE_MAX_LENGTH,
-  NEW_WORKSPACE_MIN_LENGTH,
-} from "@/constants";
-
-const formSchema = z.object({
-  name: z
-    .string()
-    .min(
-      NEW_WORKSPACE_MIN_LENGTH,
-      `Name must contain at least ${NEW_WORKSPACE_MIN_LENGTH} character(s)`,
-    )
-    .max(
-      NEW_WORKSPACE_MAX_LENGTH,
-      `Name must contain at most ${NEW_WORKSPACE_MAX_LENGTH} character(s)`,
-    ),
-});
+import { renameNewWorkspace } from "@/lib/actions/workspaces";
+import WorkspaceModalContent, {
+  WorkspaceFormValues,
+} from "@/features/workspaces/workspace-modal-content";
 
 type Props = {
   workspace: {
@@ -59,18 +24,11 @@ const RenameWorkspaceModal = ({
   onOpenChange,
   onRefetchWorkspaces,
 }: Props) => {
-  const form = useForm<z.infer<typeof formSchema>>({
-    resolver: zodResolver(formSchema),
-    defaultValues: {
-      name: workspace.name,
-    },
-  });
-
-  const onSubmit = async (values: z.infer<typeof formSchema>) => {
+  const onSubmit = async (values: WorkspaceFormValues, reset: () => void) => {
     const result = await renameNewWorkspace(workspace.id, values.name);
     if (result.success) {
       onRefetchWorkspaces();
-      form.reset();
+      reset();
       toast.success("Workspace renamed successfully!");
       onOpenChange(false);
     } else {
@@ -81,42 +39,14 @@ const RenameWorkspaceModal = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[425px]">
-        <Form {...form}>
-          <form
-            className="flex flex-col gap-4"
-            onSubmit={form.handleSubmit(onSubmit)}
-          >
-            <DialogHeader>
-              <DialogTitle>Rename Workspace</DialogTitle>
-              <DialogDescription>
-                Enter a new name for your workspace.
-              </DialogDescription>
-            </DialogHeader>
-            <FormField
-              control={form.control}
-              name="name"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>New Name</FormLabel>
-                  <FormControl>
-                    <Input placeholder="e.g. Marketing team" {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <DialogFooter>
-              <DialogClose asChild>
-                <Button variant="outline">Cancel</Button>
-              </DialogClose>
-              <Button type="submit" disabled={form.formState.isSubmitting}>
-                {form.formState.isSubmitting ? "Renaming..." : "Rename"}
-              </Button>
-            </DialogFooter>
-          </form>
-        </Form>
-      </DialogContent>
+      <WorkspaceModalContent
+        title="Rename Workspace"
+        description="Enter a new name for your workspace."
+        submitLabel="Rename"
+        submittingLabel="Renaming..."
+        defaultName={workspace.name}
+        onSubmit={onSubmit}
+      />
     </Dialog>
   );
 };

--- a/apps/web/features/workspaces/rename-workspace/rename-workspace-modal.tsx
+++ b/apps/web/features/workspaces/rename-workspace/rename-workspace-modal.tsx
@@ -1,11 +1,9 @@
-"use client";
-
 import { Dialog } from "@repo/ui/components/dialog";
 import { toast } from "sonner";
 import { clientAuthGuard } from "@/utils/client-auth-guard";
 import { renameNewWorkspace } from "@/lib/actions/workspaces";
 import WorkspaceModalContent, {
-  WorkspaceFormValues,
+  type WorkspaceFormValues,
 } from "@/features/workspaces/workspace-modal-content";
 
 type Props = {

--- a/apps/web/features/workspaces/rename-workspace/rename-workspace-modal.tsx
+++ b/apps/web/features/workspaces/rename-workspace/rename-workspace-modal.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@repo/ui/components/dialog";
+import { Button } from "@repo/ui/components/button";
+import { Input } from "@repo/ui/components/input";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@repo/ui/components/form";
+import { toast } from "sonner";
+import { clientAuthGuard } from "@/utils/client-auth-guard";
+import { renameNewWorkspace } from "@/lib/actions/workspaces"; // <- replace with renameWorkspace when available
+import {
+  NEW_WORKSPACE_MAX_LENGTH,
+  NEW_WORKSPACE_MIN_LENGTH,
+} from "@/constants";
+
+const formSchema = z.object({
+  name: z
+    .string()
+    .min(
+      NEW_WORKSPACE_MIN_LENGTH,
+      `Name must contain at least ${NEW_WORKSPACE_MIN_LENGTH} character(s)`,
+    )
+    .max(
+      NEW_WORKSPACE_MAX_LENGTH,
+      `Name must contain at most ${NEW_WORKSPACE_MAX_LENGTH} character(s)`,
+    ),
+});
+
+type Props = {
+  workspace: {
+    id: string;
+    name: string;
+  };
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onRefetchWorkspaces: () => void;
+};
+
+const RenameWorkspaceModal = ({
+  workspace,
+  open,
+  onOpenChange,
+  onRefetchWorkspaces,
+}: Props) => {
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: workspace.name,
+    },
+  });
+
+  const onSubmit = async (values: z.infer<typeof formSchema>) => {
+    const result = await renameNewWorkspace(workspace.id, values.name);
+    if (result.success) {
+      onRefetchWorkspaces();
+      form.reset();
+      toast.success("Workspace renamed successfully!");
+      onOpenChange(false);
+    } else {
+      clientAuthGuard(result.status);
+      toast.error("Could not rename the workspace");
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[425px]">
+        <Form {...form}>
+          <form
+            className="flex flex-col gap-4"
+            onSubmit={form.handleSubmit(onSubmit)}
+          >
+            <DialogHeader>
+              <DialogTitle>Rename Workspace</DialogTitle>
+              <DialogDescription>
+                Enter a new name for your workspace.
+              </DialogDescription>
+            </DialogHeader>
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>New Name</FormLabel>
+                  <FormControl>
+                    <Input placeholder="e.g. Marketing team" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button variant="outline">Cancel</Button>
+              </DialogClose>
+              <Button type="submit" disabled={form.formState.isSubmitting}>
+                {form.formState.isSubmitting ? "Renaming..." : "Rename"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default RenameWorkspaceModal;

--- a/apps/web/features/workspaces/workspace-item-actions.tsx
+++ b/apps/web/features/workspaces/workspace-item-actions.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -6,37 +8,56 @@ import {
 } from "@repo/ui/components/dropdown-menu";
 import { SidebarMenuAction } from "@repo/ui/components/sidebar";
 import { MoreHorizontal, Pencil } from "lucide-react";
-import DeleteWorkspaceConfirmDialog from "@/features/workspaces/delete-workspace/delete-workspace-confirm-dialog";
 import { useState } from "react";
+import RenameWorkspaceModal from "@/features/workspaces/rename-workspace/rename-workspace-modal";
+import DeleteWorkspaceConfirmDialog from "@/features/workspaces/delete-workspace/delete-workspace-confirm-dialog";
+import { Workspace } from "@/types/workspace";
 
 type Props = {
-  workspaceId: string;
+  workspace: Workspace;
   onRefetchWorkspaces: () => void;
 };
 
-const WorkspaceItemActions = ({ workspaceId, onRefetchWorkspaces }: Props) => {
-  const [isOpen, setIsOpen] = useState(false);
+const WorkspaceItemActions = ({ workspace, onRefetchWorkspaces }: Props) => {
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [isRenameOpen, setIsRenameOpen] = useState(false);
 
   return (
-    <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
-      <DropdownMenuTrigger asChild>
-        <SidebarMenuAction showOnHover>
-          <MoreHorizontal />
-          <span className="sr-only">Open actions dropdown</span>
-        </SidebarMenuAction>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent side="right" align="start">
-        <DropdownMenuItem aria-label="Rename workspace">
-          <Pencil />
-          <span>Rename</span>
-        </DropdownMenuItem>
-        <DeleteWorkspaceConfirmDialog
-          workspaceId={workspaceId}
-          onCloseDropdown={() => setIsOpen(false)}
-          onRefetchWorkspaces={onRefetchWorkspaces}
-        />
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <>
+      <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>
+        <DropdownMenuTrigger asChild>
+          <SidebarMenuAction showOnHover>
+            <MoreHorizontal />
+            <span className="sr-only">Open actions dropdown</span>
+          </SidebarMenuAction>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent side="right" align="start">
+          <DropdownMenuItem
+            aria-label="Rename workspace"
+            onSelect={(e) => {
+              e.preventDefault();
+              setIsDropdownOpen(false);
+              setIsRenameOpen(true);
+            }}
+          >
+            <Pencil />
+            <span>Rename</span>
+          </DropdownMenuItem>
+
+          <DeleteWorkspaceConfirmDialog
+            workspaceId={workspace.id}
+            onCloseDropdown={() => setIsDropdownOpen(false)}
+            onRefetchWorkspaces={onRefetchWorkspaces}
+          />
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <RenameWorkspaceModal
+        workspace={workspace}
+        open={isRenameOpen}
+        onOpenChange={setIsRenameOpen}
+        onRefetchWorkspaces={onRefetchWorkspaces}
+      />
+    </>
   );
 };
 

--- a/apps/web/features/workspaces/workspace-item.tsx
+++ b/apps/web/features/workspaces/workspace-item.tsx
@@ -17,7 +17,7 @@ import { Folder, FolderOpen } from "lucide-react";
 import Link from "next/link";
 import { Workspace } from "@/types/workspace";
 import { usePathname } from "next/navigation";
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 
 type Props = {
   workspace: Workspace;
@@ -59,7 +59,7 @@ const WorkspaceItem = ({ workspace, onRefetchWorkspaces }: Props) => {
         </CollapsibleTrigger>
 
         <WorkspaceItemActions
-          workspaceId={workspace.id}
+          workspace={workspace}
           onRefetchWorkspaces={onRefetchWorkspaces}
         />
 

--- a/apps/web/features/workspaces/workspace-modal-content.tsx
+++ b/apps/web/features/workspaces/workspace-modal-content.tsx
@@ -1,0 +1,108 @@
+import { z } from "zod";
+import {
+  NEW_WORKSPACE_MAX_LENGTH,
+  NEW_WORKSPACE_MIN_LENGTH,
+} from "@/constants";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@repo/ui/components/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@repo/ui/components/form";
+import { Input } from "@repo/ui/components/input";
+import { Button } from "@repo/ui/components/button";
+
+const formSchema = z.object({
+  name: z
+    .string()
+    .min(
+      NEW_WORKSPACE_MIN_LENGTH,
+      `Name must contain at least ${NEW_WORKSPACE_MIN_LENGTH} character(s)`,
+    )
+    .max(
+      NEW_WORKSPACE_MAX_LENGTH,
+      `Name must contain at most ${NEW_WORKSPACE_MAX_LENGTH} character(s)`,
+    ),
+});
+
+export type WorkspaceFormValues = z.infer<typeof formSchema>;
+
+type Props = {
+  title: string;
+  description: string;
+  submitLabel: string;
+  submittingLabel: string;
+  defaultName?: string;
+  onSubmit: (values: WorkspaceFormValues, reset: () => void) => Promise<void>;
+};
+
+const WorkspaceModalContent = ({
+  title,
+  description,
+  submitLabel,
+  submittingLabel,
+  defaultName,
+  onSubmit,
+}: Props) => {
+  const form = useForm<WorkspaceFormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: defaultName || "",
+    },
+  });
+
+  const handleSubmit = async (values: WorkspaceFormValues) => {
+    await onSubmit(values, () => form.reset());
+  };
+
+  return (
+    <DialogContent className="sm:max-w-[425px]">
+      <Form {...form}>
+        <form
+          className="flex flex-col gap-4"
+          onSubmit={form.handleSubmit(handleSubmit)}
+        >
+          <DialogHeader>
+            <DialogTitle>{title}</DialogTitle>
+            <DialogDescription>{description}</DialogDescription>
+          </DialogHeader>
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>New Name</FormLabel>
+                <FormControl>
+                  <Input placeholder="Personal project" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline">Cancel</Button>
+            </DialogClose>
+            <Button type="submit" disabled={form.formState.isSubmitting}>
+              {form.formState.isSubmitting ? submittingLabel : submitLabel}
+            </Button>
+          </DialogFooter>
+        </form>
+      </Form>
+    </DialogContent>
+  );
+};
+
+export default WorkspaceModalContent;

--- a/apps/web/lib/actions/workspaces.ts
+++ b/apps/web/lib/actions/workspaces.ts
@@ -14,6 +14,21 @@ export async function createNewWorkspace(workspaceName: string) {
   );
 }
 
+export async function renameNewWorkspace(
+  workspaceId: string,
+  workspaceName: string,
+) {
+  return callBackend(
+    `/api/workspaces/${workspaceId}`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: { name: workspaceName },
+    },
+    "Workspace created successfully",
+  );
+}
+
 export async function deleteWorkspace(workspaceId: string) {
   return callBackend(
     `/api/workspaces/${workspaceId}`,


### PR DESCRIPTION
### Github issue

- Issue URL: #172 

### Description

- Created a server action for renaming a workspace
- Created a modal for renaming a workspace
- Make the `new workspace` and `rename workspace` forms into one component

### Checklist

- [x] Code compiles correctly
- [x] Extended the README / documentation, if necessary
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Test (`pnpm run test`) has passed locally
- [x] Lint (`pnpm run lint`) has passed locally and any fixes were made for failures

### Demo (e.g. screenshots, Gifs, Videos, link to demo)

https://github.com/user-attachments/assets/55d10b36-b501-4eb5-9aa7-ce7d0c369477

